### PR TITLE
Update error helper

### DIFF
--- a/lib/prana/core/error.ex
+++ b/lib/prana/core/error.ex
@@ -52,4 +52,27 @@ defmodule Prana.Core.Error do
       details: details
     }
   end
+
+  @doc """
+  Creates an action error with specific error type preserved in details.
+  This helps maintain backwards compatibility while standardizing the structure.
+
+  ## Parameters
+  - `error_type`: Specific error type (e.g., "config_error", "http_error")
+  - `message`: Human-readable error description
+  - `extra_details`: Optional map with additional context
+
+  ## Examples
+
+      iex> Prana.Core.Error.action_error("config_error", "Invalid mode")
+      %Prana.Core.Error{code: "action_error", message: "Invalid mode", details: %{"error_type" => "config_error"}}
+
+      iex> Prana.Core.Error.action_error("http_error", "Request failed", %{status_code: 404})
+      %Prana.Core.Error{code: "action_error", message: "Request failed", details: %{"error_type" => "http_error", status_code: 404}}
+  """
+  @spec action_error(String.t(), String.t(), map()) :: t()
+  def action_error(error_type, message, extra_details \\ %{}) do
+    details = Map.merge(%{"error_type" => error_type}, extra_details)
+    new("action_error", message, details)
+  end
 end

--- a/lib/prana/core/workflow_execution.ex
+++ b/lib/prana/core/workflow_execution.ex
@@ -837,7 +837,7 @@ defmodule Prana.WorkflowExecution do
           {:cont, {:ok, updated_prep_data}}
 
         {:error, reason} ->
-          {:halt, {:error, %{type: "action_preparation_failed", node_key: node.key, reason: reason}}}
+          {:halt, {:error, Error.new("action_preparation_failed", "Action preparation failed", %{"node_key" => node.key, "reason" => reason})}}
       end
     end)
   end

--- a/lib/prana/execution/graph_executor.ex
+++ b/lib/prana/execution/graph_executor.ex
@@ -452,7 +452,7 @@ defmodule Prana.GraphExecutor do
   end
 
   def resume_workflow(%WorkflowExecution{status: status}, _resume_data, _options) do
-    {:error, %{type: "invalid_execution_status", message: "Can only resume suspended executions", status: status}}
+    {:error, Error.new("invalid_execution_status", "Can only resume suspended executions", %{"status" => status})}
   end
 
   # Prepare execution for resume by rebuilding runtime state
@@ -465,7 +465,7 @@ defmodule Prana.GraphExecutor do
   # Validate that the suspended execution has a valid suspended node ID
   defp validate_suspended_node_id(prepared_execution) do
     case prepared_execution.suspended_node_id do
-      nil -> {:error, %{type: "invalid_suspended_execution", message: "Cannot find suspended node ID"}}
+      nil -> {:error, Error.new("invalid_suspended_execution", "Cannot find suspended node ID")}
       suspended_node_id -> {:ok, suspended_node_id}
     end
   end
@@ -492,7 +492,7 @@ defmodule Prana.GraphExecutor do
           {:error, reason}
       end
     else
-      {:error, %{type: "suspended_node_not_found", node_key: suspended_node_id}}
+      {:error, Error.new("suspended_node_not_found", "Suspended node not found", %{"node_key" => suspended_node_id})}
     end
   end
 end

--- a/lib/prana/integrations/data/merge.ex
+++ b/lib/prana/integrations/data/merge.ex
@@ -32,7 +32,7 @@ defmodule Prana.Integrations.Data.MergeAction do
         {:ok, merged_data}
 
       {:error, reason} ->
-        {:error, Error.new("action_error", reason)}
+        {:error, Error.action_error("merge_error", reason)}
     end
   end
 

--- a/lib/prana/integrations/http/request_action.ex
+++ b/lib/prana/integrations/http/request_action.ex
@@ -97,13 +97,13 @@ defmodule Prana.Integrations.HTTP.RequestAction do
         {:ok, format_response(response), "success"}
 
       {:error, :timeout} ->
-        {:error, Error.new("action_error", "Request timed out"), "timeout"}
+        {:error, Error.action_error("http_timeout", "Request timed out"), "timeout"}
 
       {:error, reason} when is_binary(reason) ->
-        {:error, Error.new("action_error", reason), "error"}
+        {:error, Error.action_error("http_error", reason), "error"}
 
       {:error, reason} ->
-        {:error, Error.new("action_error", format_error(reason)), "error"}
+        {:error, Error.action_error("http_error", format_error(reason)), "error"}
     end
   end
 

--- a/lib/prana/integrations/logic/switch_action.ex
+++ b/lib/prana/integrations/logic/switch_action.ex
@@ -27,6 +27,7 @@ defmodule Prana.Integrations.Logic.SwitchAction do
   use Prana.Actions.SimpleAction
 
   alias Prana.Action
+  alias Prana.Core.Error
 
   def specification do
     %Action{
@@ -50,7 +51,7 @@ defmodule Prana.Integrations.Logic.SwitchAction do
         {:ok, nil, case_port}
 
       :no_match ->
-        {:error, %{type: "no_matching_case", message: "No matching case found"}}
+        {:error, Error.action_error("no_matching_case", "No matching case found")}
     end
   end
 

--- a/lib/prana/integrations/wait.ex
+++ b/lib/prana/integrations/wait.ex
@@ -69,8 +69,8 @@ defmodule Prana.Integrations.Wait do
       "interval" -> wait_interval(params)
       "schedule" -> wait_schedule(params)
       "webhook" -> wait_webhook(params)
-      nil -> {:error, Error.new("action_error", "mode is required"), "error"}
-      _ -> {:error, Error.new("action_error", "mode must be 'interval', 'schedule', or 'webhook'"), "error"}
+      nil -> {:error, Error.action_error("config_error", "mode is required"), "error"}
+      _ -> {:error, Error.action_error("config_error", "mode must be 'interval', 'schedule', or 'webhook'"), "error"}
     end
   end
 
@@ -101,7 +101,7 @@ defmodule Prana.Integrations.Wait do
       end
     else
       {:error, reason} ->
-        {:error, Error.new("action_error", reason), "error"}
+        {:error, Error.action_error("interval_config_error", reason), "error"}
     end
   end
 
@@ -129,7 +129,7 @@ defmodule Prana.Integrations.Wait do
       {:suspend, :schedule, schedule_data}
     else
       {:error, reason} ->
-        {:error, Error.new("action_error", reason), "error"}
+        {:error, Error.action_error("schedule_config_error", reason), "error"}
     end
   end
 
@@ -162,7 +162,7 @@ defmodule Prana.Integrations.Wait do
         {:suspend, :webhook, webhook_data}
 
       {:error, reason} ->
-        {:error, Error.new("action_error", reason), "error"}
+        {:error, Error.action_error("webhook_config_error", reason), "error"}
     end
   end
 

--- a/lib/prana/integrations/workflow/execute_workflow_action.ex
+++ b/lib/prana/integrations/workflow/execute_workflow_action.ex
@@ -81,7 +81,7 @@ defmodule Prana.Integrations.Workflow.ExecuteWorkflowAction do
       end
     else
       {:error, reason} ->
-        {:error, Error.new("action_error", reason), "error"}
+        {:error, Error.action_error("sub_workflow_setup_error", reason), "error"}
     end
   end
 
@@ -103,7 +103,7 @@ defmodule Prana.Integrations.Workflow.ExecuteWorkflowAction do
 
       %{"status" => "failed", "error" => error} when failure_strategy == "fail_parent" ->
         # Sub-workflow failed and should fail parent
-        {:error, Error.new("action_error", "Sub-workflow failed", %{sub_workflow_error: error}), "error"}
+        {:error, Error.action_error("sub_workflow_failed", "Sub-workflow failed", %{sub_workflow_error: error}), "error"}
 
       %{"status" => "failed", "error" => error} when failure_strategy == "continue" ->
         # Sub-workflow failed but parent should continue
@@ -111,7 +111,7 @@ defmodule Prana.Integrations.Workflow.ExecuteWorkflowAction do
 
       %{"status" => "timeout"} when failure_strategy == "fail_parent" ->
         # Sub-workflow timed out and should fail parent
-        {:error, Error.new("action_error", "Sub-workflow execution timed out"), "error"}
+        {:error, Error.action_error("sub_workflow_timeout", "Sub-workflow execution timed out"), "error"}
 
       %{"status" => "timeout"} when failure_strategy == "continue" ->
         # Sub-workflow timed out but parent should continue

--- a/lib/prana/node_executor.ex
+++ b/lib/prana/node_executor.ex
@@ -8,6 +8,7 @@ defmodule Prana.NodeExecutor do
   - Output processing and port determination
   - Basic error handling
   """
+  alias Prana.Core.Error
   alias Prana.IntegrationRegistry
   alias Prana.Node
   alias Prana.NodeExecution
@@ -103,11 +104,7 @@ defmodule Prana.NodeExecutor do
   end
 
   defp build_params_error(type, reason, params) do
-    %{
-      "type" => type,
-      "reason" => reason,
-      "params" => params
-    }
+    Error.new("params_error", reason, %{"error_type" => type, "params" => params})
   end
 
   # =============================================================================

--- a/test/prana/execution/graph_executor_sub_workflow_test.exs
+++ b/test/prana/execution/graph_executor_sub_workflow_test.exs
@@ -346,9 +346,9 @@ defmodule Prana.WorkflowExecution.GraphExecutorSubWorkflowTest do
         )
 
       assert {:error, error_data} = result
-      assert error_data.type == "invalid_execution_status"
+      assert error_data.code == "invalid_execution_status"
       assert error_data.message == "Can only resume suspended executions"
-      assert error_data.status == :completed
+      assert error_data.details["status"] == :completed
     end
 
     test "returns error for invalid suspended execution" do
@@ -392,7 +392,7 @@ defmodule Prana.WorkflowExecution.GraphExecutorSubWorkflowTest do
         )
 
       assert {:error, error_data} = result
-      assert error_data.type == "invalid_suspended_execution"
+      assert error_data.code == "invalid_suspended_execution"
       assert error_data.message == "Cannot find suspended node ID"
     end
   end

--- a/test/prana/integrations/logic_test.exs
+++ b/test/prana/integrations/logic_test.exs
@@ -155,7 +155,7 @@ defmodule Prana.Integrations.LogicTest do
 
       context = %{}
 
-      assert {:error, %{type: "no_matching_case", message: "No matching case found"}} =
+      assert {:error, %Prana.Core.Error{code: "action_error", message: "No matching case found", details: %{"error_type" => "no_matching_case"}}} =
                SwitchAction.execute(params, context)
     end
 
@@ -163,7 +163,7 @@ defmodule Prana.Integrations.LogicTest do
       params = %{"cases" => []}
       context = %{}
 
-      assert {:error, %{type: "no_matching_case", message: "No matching case found"}} =
+      assert {:error, %Prana.Core.Error{code: "action_error", message: "No matching case found", details: %{"error_type" => "no_matching_case"}}} =
                SwitchAction.execute(params, context)
     end
 
@@ -171,7 +171,7 @@ defmodule Prana.Integrations.LogicTest do
       params = %{}
       context = %{}
 
-      assert {:error, %{type: "no_matching_case", message: "No matching case found"}} =
+      assert {:error, %Prana.Core.Error{code: "action_error", message: "No matching case found", details: %{"error_type" => "no_matching_case"}}} =
                SwitchAction.execute(params, context)
     end
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new action_error function to standardize error struct creation with preserved error_type and migrate existing error handling to use it for consistency across the codebase

New Features:
- Add action_error helper in Prana.Core.Error for standardized error struct creation preserving error_type

Enhancements:
- Refactor error creation across modules to use the new action_error helper (Wait, HTTP, Workflow, GraphExecutor, NodeExecutor, SwitchAction, MergeAction)
- Alias Prana.Core.Error in NodeExecutor
- Replace inline error maps with Error.new for consistency

Documentation:
- Document action_error in Prana.Core.Error with examples

Tests:
- Update tests to assert on Prana.Core.Error struct fields (code, details) instead of raw maps