### PR TITLE
Enhance set_data action with dual-mode functionality

### DIFF
--- a/docs/tasks/enhance-set-data-action.md
+++ b/docs/tasks/enhance-set-data-action.md
@@ -1,0 +1,132 @@
+
+# Task: Enhance `set_data` Action
+
+**Date:** 2025-07-27
+**Status:** ✅ Completed
+
+## 1. Background
+
+The existing `data.set_data` action is a simple pass-through node that outputs its parameters. This is insufficient for real-world workflows that require dynamic data construction and transformation. The goal is to evolve this action into a powerful and flexible tool for data manipulation, similar to the "Set" or "Transform" nodes in platforms like n8n.
+
+## 2. Proposed Solution
+
+The `set_data` action will be enhanced to support two distinct operating modes, selectable via a `mode` parameter. This provides both a simple interface for basic key-value mapping and a powerful templating system for complex, nested data structures.
+
+### 2.1. Action Parameters
+
+The action's `params` will be structured as follows:
+
+- `mode` (string, optional): The operating mode.
+  - `"manual"` (default): For simple, one-level key-value mapping.
+  - `"json"`: For creating complex, nested data structures from a JSON template.
+- `mapping_map` (map, optional): A map used in `manual` mode. Each value is a template string that will be rendered.
+- `json_template` (string, optional): A string containing a JSON structure, used in `json` mode. The entire string is rendered as a template.
+
+### 2.2. Example Usage
+
+#### Manual Mode
+
+This mode is for creating or modifying a flat map.
+
+**Params:**
+```json
+{
+  "mode": "manual",
+  "mapping_map": {
+    "user_id": "{{ $input.id }}",
+    "full_name": "{{ $input.first_name | capitalize }} {{ $input.last_name | capitalize }}",
+    "status": "processed"
+  }
+}
+```
+
+**Output:**
+```json
+{
+  "user_id": 123,
+  "full_name": "John Doe",
+  "status": "processed"
+}
+```
+
+#### JSON Mode
+
+This mode is for creating complex, nested JSON objects or arrays.
+
+**Params:**
+```json
+{
+  "mode": "json",
+  "json_template": "{ \"user\": { \"id\": {{ $input.user.id }}, \"name\": \"{{ $input.user.name | upper_case }}\" }, \"orders\": [ {%- for order in $input.orders -%} { \"order_id\": \"{{ order.id }}\", \"amount\": {{ order.amount }} } {%- if not loop.last -%},{%- endif -%} {%- endfor -%} ] }"
+}
+```
+
+**Output:**
+```json
+{
+  "user": {
+    "id": 456,
+    "name": "JANE DOE"
+  },
+  "orders": [
+    {
+      "order_id": "ord_1",
+      "amount": 99.99
+    },
+    {
+      "order_id": "ord_2",
+      "amount": 12.50
+    }
+  ]
+}
+```
+
+## 3. Implementation Plan
+
+### Step 1: Dependency Management
+
+1.  **Inspect `mix.lock`**: Check for an existing JSON parsing library (e.g., `jason`, `poison`).
+2.  **Add Dependency (if needed)**: If no suitable library exists, add `{:jason, "~> 1.4"}` to `mix.exs` after user confirmation and run `mix deps.get`.
+
+### Step 2: Update Action Logic (`lib/prana/integrations/data/set_data_action.ex`)
+
+1.  **Update Specification**: Modify the `description` in `specification/0` to reflect the new dual-mode functionality.
+2.  **Rewrite `execute/2`**:
+    - Read the `mode` from `params`, defaulting to `"manual"`.
+    - Implement a `case` statement to handle the `mode`.
+    - **`"manual"` mode**:
+        - Get `mapping_map` from `params`.
+        - If it's a map, iterate through its values and render each one using `Prana.Template.Engine.render/2`.
+        - Return the new map with rendered values.
+    - **`"json"` mode**:
+        - Get `json_template` from `params`.
+        - If it's a string, render it using `Prana.Template.Engine.render/2`.
+        - Parse the resulting string with `Jason.decode/1`.
+        - Return the parsed map or list.
+    - **Error Handling**: Implement robust error handling for missing parameters, template rendering failures, and JSON parsing errors. Return structured error tuples.
+
+### Step 3: Unit Testing (`test/prana/integrations/data/set_data_action_test.exs`)
+
+1.  **Create Test File**: Create the test file if it doesn't exist.
+2.  **Write Test Cases**:
+    - **Manual Mode**:
+        - Test successful key-value mapping.
+        - Test behavior with a missing or empty `mapping_map`.
+        - Test a template rendering error in one of the values.
+    - **JSON Mode**:
+        - Test successful rendering and parsing of a complex JSON object.
+        - Test successful rendering and parsing of a JSON array.
+        - Test for a missing `json_template` parameter.
+        - Test for a template rendering error.
+        - Test for a JSON parsing error (i.e., the rendered string is not valid JSON).
+    - **General**:
+        - Test that the action defaults to `manual` mode when `mode` is not provided.
+        - Test that an invalid `mode` value returns an error.
+
+## 4. Acceptance Criteria
+
+- The `set_data` action correctly implements both `manual` and `json` modes.
+- The action handles missing or invalid parameters gracefully for each mode.
+- Template rendering and JSON parsing errors are caught and returned as structured error messages.
+- All unit tests pass, covering the scenarios outlined above.
+- The `mix.exs` file is updated with the `jason` dependency if it was not already present.

--- a/lib/prana/integrations/data/set_data_action.ex
+++ b/lib/prana/integrations/data/set_data_action.ex
@@ -1,6 +1,10 @@
 defmodule Prana.Integrations.Data.SetDataAction do
   @moduledoc """
-  Set Data Action - Sets data for testing purposes
+  Set Data Action - Creates or transforms data using templates
+
+  Supports two operating modes:
+  - `manual`: Simple key-value mapping (params already template-rendered by NodeExecutor)
+  - `json`: Complex nested data structures from JSON templates (template-rendered string parsed as JSON)
   """
 
   use Prana.Actions.SimpleAction
@@ -11,7 +15,7 @@ defmodule Prana.Integrations.Data.SetDataAction do
     %Action{
       name: "data.set_data",
       display_name: "Set Data",
-      description: "Set data",
+      description: "Create or transform data using templates in manual or json mode",
       type: :action,
       module: __MODULE__,
       input_ports: ["main"],
@@ -21,6 +25,49 @@ defmodule Prana.Integrations.Data.SetDataAction do
 
   @impl true
   def execute(params, _context) do
-    {:ok, params}
+    mode = Map.get(params, "mode", "manual")
+
+    case mode do
+      "manual" ->
+        execute_manual_mode(params)
+
+      "json" ->
+        execute_json_mode(params)
+
+      invalid_mode ->
+        {:error, "Invalid mode '#{invalid_mode}'. Supported modes: 'manual', 'json'"}
+    end
+  end
+
+  defp execute_manual_mode(params) do
+    case Map.get(params, "mapping_map") do
+      nil ->
+        {:ok, nil}
+
+      mapping_map when is_map(mapping_map) ->
+        {:ok, mapping_map}
+
+      _ ->
+        {:error, "Parameter 'mapping_map' must be a map"}
+    end
+  end
+
+  defp execute_json_mode(params) do
+    case Map.get(params, "json_template") do
+      nil ->
+        {:ok, nil}
+
+      json_template when is_binary(json_template) ->
+        case Jason.decode(json_template) do
+          {:ok, parsed_data} ->
+            {:ok, parsed_data}
+
+          {:error, %Jason.DecodeError{} = error} ->
+            {:error, "JSON parsing failed: #{Exception.message(error)}"}
+        end
+
+      _ ->
+        {:error, "Parameter 'json_template' must be a string"}
+    end
   end
 end

--- a/test/prana/integrations/data/set_data_action_test.exs
+++ b/test/prana/integrations/data/set_data_action_test.exs
@@ -1,0 +1,151 @@
+defmodule Prana.Integrations.Data.SetDataActionTest do
+  use ExUnit.Case, async: true
+
+  alias Prana.Integrations.Data.SetDataAction
+
+  describe "execute/2 - manual mode" do
+    test "returns mapping_map when provided" do
+      params = %{
+        "mode" => "manual",
+        "mapping_map" => %{
+          "user_id" => 123,
+          "full_name" => "John Doe",
+          "status" => "processed"
+        }
+      }
+
+      assert {:ok, result} = SetDataAction.execute(params, %{})
+
+      assert result == %{
+               "user_id" => 123,
+               "full_name" => "John Doe",
+               "status" => "processed"
+             }
+    end
+
+    test "returns nil when mapping_map is missing" do
+      params = %{"mode" => "manual"}
+
+      assert {:ok, nil} = SetDataAction.execute(params, %{})
+    end
+
+    test "returns error when mapping_map is not a map" do
+      params = %{
+        "mode" => "manual",
+        "mapping_map" => "not_a_map"
+      }
+
+      assert {:error, error} = SetDataAction.execute(params, %{})
+      assert error == "Parameter 'mapping_map' must be a map"
+    end
+
+    test "defaults to manual mode when mode not specified" do
+      params = %{
+        "mapping_map" => %{"key" => "value"}
+      }
+
+      assert {:ok, result} = SetDataAction.execute(params, %{})
+      assert result == %{"key" => "value"}
+    end
+  end
+
+  describe "execute/2 - json mode" do
+    test "parses valid JSON template" do
+      json_string = ~s|{"user":{"id":456,"name":"JANE DOE"},"orders":[{"order_id":"ord_1","amount":99.99}]}|
+
+      params = %{
+        "mode" => "json",
+        "json_template" => json_string
+      }
+
+      assert {:ok, result} = SetDataAction.execute(params, %{})
+
+      assert result == %{
+               "user" => %{"id" => 456, "name" => "JANE DOE"},
+               "orders" => [%{"order_id" => "ord_1", "amount" => 99.99}]
+             }
+    end
+
+    test "parses JSON array" do
+      json_string = ~s|[{"id":1,"name":"Item 1"},{"id":2,"name":"Item 2"}]|
+
+      params = %{
+        "mode" => "json",
+        "json_template" => json_string
+      }
+
+      assert {:ok, result} = SetDataAction.execute(params, %{})
+
+      assert result == [
+               %{"id" => 1, "name" => "Item 1"},
+               %{"id" => 2, "name" => "Item 2"}
+             ]
+    end
+
+    test "returns nil when json_template is missing" do
+      params = %{"mode" => "json"}
+
+      assert {:ok, nil} = SetDataAction.execute(params, %{})
+    end
+
+    test "returns error when json_template is not a string" do
+      params = %{
+        "mode" => "json",
+        "json_template" => %{"not" => "string"}
+      }
+
+      assert {:error, error} = SetDataAction.execute(params, %{})
+      assert error == "Parameter 'json_template' must be a string"
+    end
+
+    test "returns error for invalid JSON" do
+      params = %{
+        "mode" => "json",
+        "json_template" => ~s|{"invalid": json}|
+      }
+
+      assert {:error, error} = SetDataAction.execute(params, %{})
+      assert String.starts_with?(error, "JSON parsing failed:")
+    end
+
+    test "returns error for malformed JSON" do
+      params = %{
+        "mode" => "json",
+        "json_template" => ~s|{"unclosed": "object"|
+      }
+
+      assert {:error, error} = SetDataAction.execute(params, %{})
+      assert String.starts_with?(error, "JSON parsing failed:")
+    end
+  end
+
+  describe "execute/2 - error handling" do
+    test "returns error for invalid mode" do
+      params = %{"mode" => "invalid_mode"}
+
+      assert {:error, error} = SetDataAction.execute(params, %{})
+      assert error == "Invalid mode 'invalid_mode'. Supported modes: 'manual', 'json'"
+    end
+
+    test "returns error for unknown mode" do
+      params = %{"mode" => "xml"}
+
+      assert {:error, error} = SetDataAction.execute(params, %{})
+      assert error == "Invalid mode 'xml'. Supported modes: 'manual', 'json'"
+    end
+  end
+
+  describe "specification/0" do
+    test "returns correct action specification" do
+      spec = SetDataAction.specification()
+
+      assert spec.name == "data.set_data"
+      assert spec.display_name == "Set Data"
+      assert spec.description == "Create or transform data using templates in manual or json mode"
+      assert spec.type == :action
+      assert spec.module == SetDataAction
+      assert spec.input_ports == ["main"]
+      assert spec.output_ports == ["main", "error"]
+    end
+  end
+end


### PR DESCRIPTION
- Add manual mode for simple key-value mapping (default)
- Add json mode for complex nested data structures
- Leverage NodeExecutor's template rendering system
- Return nil for missing parameters instead of errors
- Add comprehensive test suite with 13 test cases
- Update documentation with examples and mode explanations

🤖 Generated with [Claude Code](https://claude.ai/code)