### PR TITLE
Clean up error port from code

### DIFF
--- a/docs/integrations/data.md
+++ b/docs/integrations/data.md
@@ -12,7 +12,7 @@ The Data integration provides essential data manipulation capabilities for combi
 - **Action Name**: `merge`
 - **Description**: Combine data from multiple named input ports (diamond pattern coordination)
 - **Input Ports**: `["input_a", "input_b"]`
-- **Output Ports**: `["main", "error"]`
+- **Output Ports**: `["main"]`
 
 **Input Parameters**:
 - `strategy`: Merge strategy (`"append"` | `"merge"` | `"concat"`) - defaults to `"append"`
@@ -65,7 +65,7 @@ The Data integration provides essential data manipulation capabilities for combi
 - **Action Name**: `set_data`
 - **Description**: Create or transform data using templates in manual or json mode
 - **Input Ports**: `["main"]`
-- **Output Ports**: `["main", "error"]`
+- **Output Ports**: `["main"]`
 
 **Input Parameters**:
 - `mode`: Operating mode (`"manual"` | `"json"`) - defaults to `"manual"`

--- a/lib/prana/core/action.ex
+++ b/lib/prana/core/action.ex
@@ -11,7 +11,7 @@ defmodule Prana.Action do
         description: "Make HTTP requests (GET, POST, PUT, DELETE, etc.)",
         module: MyApp.HttpRequestAction,
         input_ports: ["input"],
-        output_ports: ["main", "error", "timeout"],
+        output_ports: ["main", "timeout"],
 
         params_schema: %{
           type: "object",

--- a/test/prana/end_to_end_retry_test.exs
+++ b/test/prana/end_to_end_retry_test.exs
@@ -26,7 +26,7 @@ defmodule Prana.EndToEndRetryTest do
         type: :action,
         module: __MODULE__,
         input_ports: ["main"],
-        output_ports: ["main", "error"]
+        output_ports: ["main"]
       }
     end
 
@@ -69,7 +69,7 @@ defmodule Prana.EndToEndRetryTest do
         type: :action,
         module: __MODULE__,
         input_ports: ["main"],
-        output_ports: ["main", "error"]
+        output_ports: ["main"]
       }
     end
 

--- a/test/prana/graph_executor_retry_simple_test.exs
+++ b/test/prana/graph_executor_retry_simple_test.exs
@@ -26,7 +26,7 @@ defmodule Prana.GraphExecutorRetrySimpleTest do
         type: :action,
         module: __MODULE__,
         input_ports: ["main"],
-        output_ports: ["main", "error"]
+        output_ports: ["main"]
       }
     end
 
@@ -59,7 +59,7 @@ defmodule Prana.GraphExecutorRetrySimpleTest do
         type: :action,
         module: __MODULE__,
         input_ports: ["main"],
-        output_ports: ["main", "error"]
+        output_ports: ["main"]
       }
     end
 

--- a/test/prana/node_executor_dynamic_ports_test.exs
+++ b/test/prana/node_executor_dynamic_ports_test.exs
@@ -32,7 +32,7 @@ defmodule Prana.NodeExecutorDynamicPortsTest do
       # Create action with fixed ports
       fixed_action = %Action{
         name: "test_action",
-        output_ports: ["main", "error"]
+        output_ports: ["main"]
       }
 
       # Valid port should work

--- a/test/prana/node_executor_retry_node_test.exs
+++ b/test/prana/node_executor_retry_node_test.exs
@@ -25,7 +25,7 @@ defmodule Prana.NodeExecutorRetryNodeTest do
         type: :action,
         module: __MODULE__,
         input_ports: ["main"],
-        output_ports: ["main", "error"]
+        output_ports: ["main"]
       }
     end
 
@@ -58,7 +58,7 @@ defmodule Prana.NodeExecutorRetryNodeTest do
         type: :action,
         module: __MODULE__,
         input_ports: ["main"],
-        output_ports: ["main", "error"]
+        output_ports: ["main"]
       }
     end
 

--- a/test/prana/node_executor_retry_test.exs
+++ b/test/prana/node_executor_retry_test.exs
@@ -24,7 +24,7 @@ defmodule Prana.NodeExecutorRetryTest do
         type: :action,
         module: __MODULE__,
         input_ports: ["main"],
-        output_ports: ["main", "error"]
+        output_ports: ["main"]
       }
     end
 
@@ -48,7 +48,7 @@ defmodule Prana.NodeExecutorRetryTest do
         type: :action,
         module: __MODULE__,
         input_ports: ["main"],
-        output_ports: ["main", "error"]
+        output_ports: ["main"]
       }
     end
 

--- a/test/prana/node_executor_suspension_test.exs
+++ b/test/prana/node_executor_suspension_test.exs
@@ -195,7 +195,7 @@ defmodule Prana.NodeExecutorSuspensionTest do
     test "processes suspension tuple correctly" do
       action = %Action{
         name: "test_action",
-        output_ports: ["main", "error"]
+        output_ports: ["main"]
       }
 
       suspension_data = %{workflow_id: "test", data: %{}}
@@ -209,7 +209,7 @@ defmodule Prana.NodeExecutorSuspensionTest do
     test "handles different suspension types" do
       action = %Action{
         name: "test_action",
-        output_ports: ["main", "error"]
+        output_ports: ["main"]
       }
 
       # Test different suspension types
@@ -235,7 +235,7 @@ defmodule Prana.NodeExecutorSuspensionTest do
     test "validates suspension tuple format" do
       action = %Action{
         name: "test_action",
-        output_ports: ["main", "error"]
+        output_ports: ["main"]
       }
 
       # Invalid suspension type (not an atom)

--- a/test/prana/node_executor_test.exs
+++ b/test/prana/node_executor_test.exs
@@ -124,7 +124,7 @@ defmodule Prana.NodeExecutorTest do
           description: "Action that returns an error with explicit port",
           type: :action,
           input_ports: ["input"],
-          output_ports: ["main", "error", "validation_error"]
+          output_ports: ["main", "validation_error"]
         }
       end
 

--- a/test/support/integrations/test_actions/process_adult_action.ex
+++ b/test/support/integrations/test_actions/process_adult_action.ex
@@ -14,7 +14,7 @@ defmodule Prana.TestSupport.Integrations.TestActions.ProcessAdultAction do
       description: @moduledoc,
       type: :action,
       input_ports: ["main", "input"],
-      output_ports: ["main", "error"]
+      output_ports: ["main"]
     }
   end
 

--- a/test/support/integrations/test_actions/process_minor_action.ex
+++ b/test/support/integrations/test_actions/process_minor_action.ex
@@ -14,7 +14,7 @@ defmodule Prana.TestSupport.Integrations.TestActions.ProcessMinorAction do
       description: @moduledoc,
       type: :action,
       input_ports: ["main", "input"],
-      output_ports: ["main", "error"]
+      output_ports: ["main"]
     }
   end
 

--- a/test/support/integrations/test_actions/simple_action.ex
+++ b/test/support/integrations/test_actions/simple_action.ex
@@ -14,7 +14,7 @@ defmodule Prana.TestSupport.Integrations.TestActions.SimpleAction do
       description: @moduledoc,
       type: :action,
       input_ports: ["main"],
-      output_ports: ["main", "error"]
+      output_ports: ["main"]
     }
   end
 

--- a/test/support/test_integration.ex
+++ b/test/support/test_integration.ex
@@ -43,7 +43,7 @@ defmodule Prana.TestSupport.TestIntegration.SimpleTestAction do
       description: "A simple test action that can succeed or fail",
       type: :action,
       input_ports: ["input"],
-      output_ports: ["main", "error"]
+      output_ports: ["main"]
     }
   end
 


### PR DESCRIPTION
## Summary by Sourcery

Remove the obsolete "error" output port from action definitions and synchronize tests and documentation accordingly.

Enhancements:
- Drop the "error" port from output_ports in core action definitions and test action modules

Documentation:
- Remove references to the "error" output port in integration documentation

Tests:
- Update multiple test suites to expect only the "main" (and other relevant) ports instead of including "error"