### PR TITLE
Implement run debug node

### DIFF
--- a/lib/prana/graph_executor.ex
+++ b/lib/prana/graph_executor.ex
@@ -366,26 +366,21 @@ defmodule Prana.GraphExecutor do
           | {:error, WorkflowExecution.t()}
           | {:error, term()}
   def execute_node(%WorkflowExecution{} = execution, node_key, input_data \\ nil) do
-    case Map.get(execution.execution_graph.node_map, node_key) do
-      nil ->
-        {:error, Error.new("node_not_found", "Node not found in execution graph", %{node_key: node_key})}
+    with {:ok, node} <- fetch_node(execution, node_key) do
+      custom_input = if input_data, do: %{"main" => input_data}, else: nil
 
-      node ->
-        custom_input = if input_data, do: %{"main" => input_data}, else: nil
+      case execute_single_node(node, execution, custom_input) do
+        {:ok, updated_execution, _output_data} ->
+          node_execution =
+            updated_execution.node_executions
+            |> Map.get(node_key, [])
+            |> List.first()
 
-        case execute_single_node(node, execution, custom_input) do
-          {:ok, updated_execution, _output_data} ->
-            # Retrieve the NodeExecution record that was just added
-            node_execution =
-              updated_execution.node_executions
-              |> Map.get(node_key, [])
-              |> List.first()
+          {:ok, node_execution, updated_execution}
 
-            {:ok, node_execution, updated_execution}
-
-          other ->
-            other
-        end
+        other ->
+          other
+      end
     end
   end
 
@@ -405,34 +400,38 @@ defmodule Prana.GraphExecutor do
 
   ## Returns
 
-  - `{:ok, WorkflowExecution.t()}` - Workflow completed
-  - `{:suspend, WorkflowExecution.t(), suspension_data}` - Workflow suspended
+  - `{:ok, WorkflowExecution.t(), last_output}` - Workflow completed; `last_output` is the output data of the final node executed
+  - `{:suspend, suspended_execution, suspension_data}` - Workflow suspended
   - `{:error, WorkflowExecution.t()}` - Execution failed
   - `{:error, term()}` - Node key not found
   """
   @spec execute_from_node(WorkflowExecution.t(), String.t(), map() | nil) ::
-          {:ok, WorkflowExecution.t()}
+          {:ok, WorkflowExecution.t(), term()}
           | {:suspend, WorkflowExecution.t(), map()}
           | {:error, WorkflowExecution.t()}
           | {:error, term()}
   def execute_from_node(%WorkflowExecution{} = execution, node_key, input_data \\ nil) do
+    with {:ok, node} <- fetch_node(execution, node_key) do
+      custom_input = if input_data, do: %{"main" => input_data}, else: nil
+
+      case execute_single_node(node, execution, custom_input) do
+        {:ok, updated_execution, _node_output} ->
+          execute_workflow_loop(updated_execution)
+
+        {:suspend, suspended_execution, suspension_data} ->
+          {:suspend, suspended_execution, suspension_data}
+
+        {:error, failed_execution} ->
+          {:error, failed_execution}
+      end
+    end
+  end
+
+  # Look up a node by key, returning a tagged tuple for use in `with` chains.
+  defp fetch_node(execution, node_key) do
     case Map.get(execution.execution_graph.node_map, node_key) do
-      nil ->
-        {:error, Error.new("node_not_found", "Node not found in execution graph", %{node_key: node_key})}
-
-      node ->
-        custom_input = if input_data, do: %{"main" => input_data}, else: nil
-
-        case execute_single_node(node, execution, custom_input) do
-          {:ok, updated_execution, _node_output} ->
-            execute_workflow_loop(updated_execution)
-
-          {:suspend, suspended_execution, suspension_data} ->
-            {:suspend, suspended_execution, suspension_data}
-
-          {:error, failed_execution} ->
-            {:error, failed_execution}
-        end
+      nil -> {:error, Error.new("node_not_found", "Node not found in execution graph", %{node_key: node_key})}
+      node -> {:ok, node}
     end
   end
 

--- a/lib/prana/graph_executor.ex
+++ b/lib/prana/graph_executor.ex
@@ -343,6 +343,100 @@ defmodule Prana.GraphExecutor do
   end
 
   @doc """
+  Execute a single node by key within an existing execution, without continuing the workflow.
+
+  Useful for debugging — run one node in isolation and inspect its output.
+
+  ## Parameters
+
+  - `execution` - A running `WorkflowExecution` (must have `__runtime` initialized)
+  - `node_key` - The key of the node to execute
+  - `input_data` - Optional input data map; defaults to extracting from execution runtime
+
+  ## Returns
+
+  - `{:ok, node_execution, updated_execution}` - Node completed successfully
+  - `{:suspend, suspended_execution, suspension_data}` - Node suspended
+  - `{:error, failed_execution}` - Node or execution failed
+  - `{:error, reason}` - Node key not found
+  """
+  @spec execute_node(WorkflowExecution.t(), String.t(), map() | nil) ::
+          {:ok, Prana.NodeExecution.t(), WorkflowExecution.t()}
+          | {:suspend, WorkflowExecution.t(), map()}
+          | {:error, WorkflowExecution.t()}
+          | {:error, term()}
+  def execute_node(%WorkflowExecution{} = execution, node_key, input_data \\ nil) do
+    case Map.get(execution.execution_graph.node_map, node_key) do
+      nil ->
+        {:error, Error.new("node_not_found", "Node not found in execution graph", %{node_key: node_key})}
+
+      node ->
+        custom_input = if input_data, do: %{"main" => input_data}, else: nil
+
+        case execute_single_node(node, execution, custom_input) do
+          {:ok, updated_execution, _output_data} ->
+            # Retrieve the NodeExecution record that was just added
+            node_execution =
+              updated_execution.node_executions
+              |> Map.get(node_key, [])
+              |> List.first()
+
+            {:ok, node_execution, updated_execution}
+
+          other ->
+            other
+        end
+    end
+  end
+
+  @doc """
+  Execute a workflow starting from a specific node, then continue until completion.
+
+  Useful for debugging — skip earlier nodes and drive execution from a midpoint.
+
+  The node is executed with its normal input (extracted from execution runtime unless
+  `input_data` is provided), then the workflow loop continues from there.
+
+  ## Parameters
+
+  - `execution` - A running `WorkflowExecution` (must have `__runtime` initialized)
+  - `node_key` - The key of the node to start from
+  - `input_data` - Optional input data map; defaults to extracting from execution runtime
+
+  ## Returns
+
+  - `{:ok, WorkflowExecution.t()}` - Workflow completed
+  - `{:suspend, WorkflowExecution.t(), suspension_data}` - Workflow suspended
+  - `{:error, WorkflowExecution.t()}` - Execution failed
+  - `{:error, term()}` - Node key not found
+  """
+  @spec execute_from_node(WorkflowExecution.t(), String.t(), map() | nil) ::
+          {:ok, WorkflowExecution.t()}
+          | {:suspend, WorkflowExecution.t(), map()}
+          | {:error, WorkflowExecution.t()}
+          | {:error, term()}
+  def execute_from_node(%WorkflowExecution{} = execution, node_key, input_data \\ nil) do
+    case Map.get(execution.execution_graph.node_map, node_key) do
+      nil ->
+        {:error, Error.new("node_not_found", "Node not found in execution graph", %{node_key: node_key})}
+
+      node ->
+        custom_input = if input_data, do: %{"main" => input_data}, else: nil
+
+        case execute_single_node(node, execution, custom_input) do
+          {:ok, updated_execution, _node_output} ->
+            execute_workflow_loop(updated_execution)
+
+          {:suspend, suspended_execution, suspension_data} ->
+            {:suspend, suspended_execution, suspension_data}
+
+          {:error, failed_execution} ->
+            {:error, failed_execution}
+        end
+    end
+  end
+
+  @doc """
   Resume a suspended workflow execution with sub-workflow results.
 
   ## Parameters

--- a/test/prana/execution/graph_executor_debug_api_test.exs
+++ b/test/prana/execution/graph_executor_debug_api_test.exs
@@ -1,0 +1,351 @@
+defmodule Prana.Execution.GraphExecutorDebugApiTest do
+  @moduledoc """
+  Tests for the debug-oriented GraphExecutor APIs:
+    - execute_node/3        – runs a single node and stops
+    - execute_from_node/3   – runs a node then continues the workflow to completion
+  """
+  use ExUnit.Case, async: false
+
+  alias Prana.Connection
+  alias Prana.GraphExecutor
+  alias Prana.IntegrationRegistry
+  alias Prana.Node
+  alias Prana.NodeSettings
+  alias Prana.TestSupport.TestIntegration
+  alias Prana.Workflow
+  alias Prana.WorkflowCompiler
+  alias Prana.WorkflowExecution
+
+  setup do
+    {:ok, registry_pid} = IntegrationRegistry.start_link()
+
+    Code.ensure_loaded!(TestIntegration)
+    :ok = IntegrationRegistry.register_integration(TestIntegration)
+
+    on_exit(fn ->
+      if Process.alive?(registry_pid) do
+        GenServer.stop(registry_pid)
+      end
+    end)
+
+    :ok
+  end
+
+  # ── helpers ──────────────────────────────────────────────────────────────────
+
+  defp build_workflow(nodes, connections) do
+    workflow = %Workflow{
+      id: "debug_test_workflow",
+      version: "1.0.0",
+      name: "Debug Test Workflow",
+      nodes: nodes,
+      connections: %{},
+      variables: %{}
+    }
+
+    Enum.reduce(connections, workflow, fn conn, acc ->
+      {:ok, updated} = Workflow.add_connection(acc, conn)
+      updated
+    end)
+  end
+
+  defp compile_workflow!(workflow, trigger_key \\ "trigger") do
+    {:ok, graph} = WorkflowCompiler.compile(workflow, trigger_key)
+    graph
+  end
+
+  defp initialized_execution(graph) do
+    {:ok, execution} = GraphExecutor.initialize_execution(graph)
+    WorkflowExecution.rebuild_runtime(execution)
+  end
+
+  defp node_execution_for(execution, node_key) do
+    execution.node_executions
+    |> Map.get(node_key, [])
+    |> List.first()
+  end
+
+  defp all_executed_keys(execution) do
+    execution.node_executions |> Map.keys() |> Enum.sort()
+  end
+
+  defp trigger_node(key \\ "trigger"),
+    do: %Node{key: key, type: "test.trigger_action", settings: NodeSettings.default()}
+
+  defp action_node(key),
+    do: %Node{key: key, type: "test.simple_action", settings: NodeSettings.default()}
+
+  defp failing_node(key),
+    do: %Node{key: key, type: "test.failing_action", settings: NodeSettings.default()}
+
+  # ── execute_node/3 ────────────────────────────────────────────────────────────
+
+  describe "execute_node/3 – single node execution" do
+    test "returns {:ok, node_execution, updated_execution} for a successful node" do
+      graph =
+        build_workflow(
+          [trigger_node(), action_node("step")],
+          [%Connection{from: "trigger", from_port: "main", to: "step", to_port: "input"}]
+        )
+        |> compile_workflow!()
+
+      execution = initialized_execution(graph)
+
+      assert {:ok, node_exec, updated_execution} = GraphExecutor.execute_node(execution, "trigger")
+
+      assert node_exec.node_key == "trigger"
+      assert node_exec.status == "completed"
+      assert node_exec.output_port == "main"
+
+      # Workflow should NOT be complete – only one node ran
+      assert updated_execution.status == "running"
+      assert map_size(updated_execution.node_executions) == 1
+    end
+
+    test "executes only the requested node – downstream nodes are not run" do
+      graph =
+        build_workflow(
+          [trigger_node(), action_node("step")],
+          [%Connection{from: "trigger", from_port: "main", to: "step", to_port: "input"}]
+        )
+        |> compile_workflow!()
+
+      execution = initialized_execution(graph)
+
+      {:ok, _node_exec, updated_execution} = GraphExecutor.execute_node(execution, "trigger")
+
+      assert Map.has_key?(updated_execution.node_executions, "trigger")
+      refute Map.has_key?(updated_execution.node_executions, "step")
+    end
+
+    test "accepts custom input_data and passes it to the node" do
+      graph =
+        build_workflow(
+          [trigger_node(), action_node("step")],
+          [%Connection{from: "trigger", from_port: "main", to: "step", to_port: "input"}]
+        )
+        |> compile_workflow!()
+
+      execution = initialized_execution(graph)
+      custom_input = %{"custom_key" => "custom_value"}
+
+      assert {:ok, node_exec, _updated} = GraphExecutor.execute_node(execution, "trigger", custom_input)
+      assert node_exec.status == "completed"
+      assert node_exec.node_key == "trigger"
+    end
+
+    test "returned node_execution matches the record stored in updated_execution" do
+      graph =
+        build_workflow([trigger_node()], [])
+        |> compile_workflow!()
+
+      execution = initialized_execution(graph)
+
+      {:ok, node_exec, updated_execution} = GraphExecutor.execute_node(execution, "trigger")
+
+      stored = node_execution_for(updated_execution, "trigger")
+      assert stored == node_exec
+    end
+
+    test "returns {:error, reason} when node_key does not exist" do
+      graph =
+        build_workflow([trigger_node()], [])
+        |> compile_workflow!()
+
+      execution = initialized_execution(graph)
+
+      assert {:error, reason} = GraphExecutor.execute_node(execution, "nonexistent_node")
+      assert reason.code == "node_not_found"
+      assert reason.details.node_key == "nonexistent_node"
+    end
+
+    test "returns {:error, failed_execution} when node action fails" do
+      # trigger -> failing_node; execute only failing_node with trigger output pre-loaded
+      graph =
+        build_workflow(
+          [trigger_node(), failing_node("bad")],
+          [%Connection{from: "trigger", from_port: "main", to: "bad", to_port: "input"}]
+        )
+        |> compile_workflow!()
+
+      execution =
+        graph
+        |> initialized_execution()
+        |> put_in([Access.key!(:__runtime), "nodes", "trigger"], %{
+          "output" => %{"triggered" => true},
+          "context" => %{}
+        })
+
+      assert {:error, failed_execution} = GraphExecutor.execute_node(execution, "bad")
+      assert failed_execution.status == "failed"
+    end
+
+    test "returns {:suspend, suspended_execution, suspension_data} for a suspending node" do
+      Code.ensure_loaded!(Prana.Integrations.Workflow)
+      :ok = IntegrationRegistry.register_integration(Prana.Integrations.Workflow)
+
+      graph =
+        build_workflow(
+          [
+            trigger_node(),
+            %Node{
+              key: "sub_wf",
+              type: "workflow.execute_workflow",
+              params: %{"workflow_id" => "child", "execution_mode" => "sync", "timeout_ms" => 5000},
+              settings: NodeSettings.default()
+            }
+          ],
+          [%Connection{from: "trigger", from_port: "main", to: "sub_wf", to_port: "main"}]
+        )
+        |> compile_workflow!()
+
+      execution =
+        graph
+        |> initialized_execution()
+        |> put_in([Access.key!(:__runtime), "nodes", "trigger"], %{
+          "output" => %{"triggered" => true},
+          "context" => %{}
+        })
+
+      assert {:suspend, suspended_execution, suspension_data} =
+               GraphExecutor.execute_node(execution, "sub_wf")
+
+      assert suspended_execution.status == "suspended"
+      assert suspended_execution.suspended_node_id == "sub_wf"
+      assert is_map(suspension_data)
+    end
+  end
+
+  # ── execute_from_node/3 ───────────────────────────────────────────────────────
+
+  describe "execute_from_node/3 – run node then continue to completion" do
+    test "runs the starting node and continues the workflow to completion" do
+      graph =
+        build_workflow(
+          [trigger_node(), action_node("step")],
+          [%Connection{from: "trigger", from_port: "main", to: "step", to_port: "input"}]
+        )
+        |> compile_workflow!()
+
+      execution = initialized_execution(graph)
+
+      assert {:ok, completed_execution, _output} =
+               GraphExecutor.execute_from_node(execution, "trigger")
+
+      assert completed_execution.status == "completed"
+      assert all_executed_keys(completed_execution) == ["step", "trigger"]
+    end
+
+    test "runs a mid-workflow node and continues downstream only" do
+      graph =
+        build_workflow(
+          [trigger_node(), action_node("step_a"), action_node("step_b")],
+          [
+            %Connection{from: "trigger", from_port: "main", to: "step_a", to_port: "input"},
+            %Connection{from: "step_a", from_port: "main", to: "step_b", to_port: "input"}
+          ]
+        )
+        |> compile_workflow!()
+
+      # Pre-load trigger output into runtime so step_a can read input
+      execution =
+        graph
+        |> initialized_execution()
+        |> put_in([Access.key!(:__runtime), "nodes", "trigger"], %{
+          "output" => %{"triggered" => true},
+          "context" => %{}
+        })
+
+      assert {:ok, completed_execution, _output} =
+               GraphExecutor.execute_from_node(execution, "step_a")
+
+      assert completed_execution.status == "completed"
+
+      executed = all_executed_keys(completed_execution)
+      assert "step_a" in executed
+      assert "step_b" in executed
+      refute "trigger" in executed
+    end
+
+    test "returns {:error, reason} when node_key does not exist" do
+      graph =
+        build_workflow([trigger_node()], [])
+        |> compile_workflow!()
+
+      execution = initialized_execution(graph)
+
+      assert {:error, reason} = GraphExecutor.execute_from_node(execution, "no_such_node")
+      assert reason.code == "node_not_found"
+    end
+
+    test "propagates failure when starting node fails" do
+      graph =
+        build_workflow(
+          [trigger_node(), failing_node("bad")],
+          [%Connection{from: "trigger", from_port: "main", to: "bad", to_port: "input"}]
+        )
+        |> compile_workflow!()
+
+      execution =
+        graph
+        |> initialized_execution()
+        |> put_in([Access.key!(:__runtime), "nodes", "trigger"], %{
+          "output" => %{"triggered" => true},
+          "context" => %{}
+        })
+
+      assert {:error, failed_execution} = GraphExecutor.execute_from_node(execution, "bad")
+      assert failed_execution.status == "failed"
+    end
+
+    test "accepts custom input_data and drives execution from that point" do
+      graph =
+        build_workflow(
+          [trigger_node(), action_node("step")],
+          [%Connection{from: "trigger", from_port: "main", to: "step", to_port: "input"}]
+        )
+        |> compile_workflow!()
+
+      execution = initialized_execution(graph)
+      custom_input = %{"debug" => true}
+
+      assert {:ok, completed_execution, _output} =
+               GraphExecutor.execute_from_node(execution, "trigger", custom_input)
+
+      assert completed_execution.status == "completed"
+
+      trigger_exec = node_execution_for(completed_execution, "trigger")
+      assert trigger_exec.status == "completed"
+    end
+
+    test "suspends mid-workflow when a downstream node suspends" do
+      Code.ensure_loaded!(Prana.Integrations.Workflow)
+      :ok = IntegrationRegistry.register_integration(Prana.Integrations.Workflow)
+
+      graph =
+        build_workflow(
+          [
+            trigger_node(),
+            %Node{
+              key: "sub_wf",
+              type: "workflow.execute_workflow",
+              params: %{"workflow_id" => "child", "execution_mode" => "sync", "timeout_ms" => 5000},
+              settings: NodeSettings.default()
+            }
+          ],
+          [%Connection{from: "trigger", from_port: "main", to: "sub_wf", to_port: "main"}]
+        )
+        |> compile_workflow!()
+
+      execution = initialized_execution(graph)
+
+      # Start from trigger – it will complete, then sub_wf suspends
+      assert {:suspend, suspended_execution, suspension_data} =
+               GraphExecutor.execute_from_node(execution, "trigger")
+
+      assert suspended_execution.status == "suspended"
+      assert suspended_execution.suspended_node_id == "sub_wf"
+      assert is_map(suspension_data)
+    end
+  end
+end


### PR DESCRIPTION
## Summary by Sourcery

Add debug execution entrypoints to run individual workflow nodes or resume from a specific node, with comprehensive tests.

New Features:
- Introduce execute_node/3 to run a single node within an existing workflow execution without advancing the rest of the workflow.
- Introduce execute_from_node/3 to start execution from a specified node and then continue the workflow to completion.

Tests:
- Add GraphExecutorDebugApi test suite covering single-node execution, mid-workflow starts, custom input handling, failures, suspensions, and node-not-found cases.