### PR TITLE
Improve loop handle to prevent memory overflow

### DIFF
--- a/lib/prana/core/workflow_execution.ex
+++ b/lib/prana/core/workflow_execution.ex
@@ -482,18 +482,28 @@ defmodule Prana.WorkflowExecution do
     %{execution | __runtime: runtime}
   end
 
-  # Update node executions list, handling retries by replacing same run_index
-  defp update_node_executions([], new_execution), do: [new_execution]
+  # Returns true when the node lives inside a loop construct (loop_level > 0).
+  # Loop nodes keep only the latest NodeExecution to prevent O(N) memory growth.
+  defp loop_node?(execution, node_key) do
+    case get_in(execution.execution_graph, [Access.key(:node_map), node_key]) do
+      %{metadata: %{loop_level: level}} when is_integer(level) and level > 0 -> true
+      _ -> false
+    end
+  end
 
-  defp update_node_executions(existing_executions, new_execution) do
-    # remaining_executions =
-    #   Enum.reject(existing_executions, fn ne -> ne.run_index == new_execution.run_index end)
+  # Update node executions list, handling retries by replacing same run_index.
+  # For loop nodes, keep at most 2 entries: [latest, previous].
+  # This bounds memory to O(1) per node while allowing comparison with the prior iteration.
+  defp update_node_executions([], new_execution, _loop_node?), do: [new_execution]
 
-    # Enum.sort_by([new_execution | remaining_executions], & &1.execution_index, :desc)
+  defp update_node_executions(existing_executions, new_execution, true) do
+    [new_execution, hd(existing_executions)]
+  end
+
+  defp update_node_executions(existing_executions, new_execution, false) do
     [last | remaining_executions] = existing_executions
 
     if last.run_index == new_execution.run_index do
-      # Replace existing execution with same run_index
       [new_execution | remaining_executions]
     else
       [new_execution | existing_executions]
@@ -548,7 +558,7 @@ defmodule Prana.WorkflowExecution do
     existing_executions = Map.get(execution.node_executions, node_key, [])
 
     # Update node executions list
-    updated_executions = update_node_executions(existing_executions, completed_node_execution)
+    updated_executions = update_node_executions(existing_executions, completed_node_execution, loop_node?(execution, node_key))
     updated_node_executions = Map.put(execution.node_executions, node_key, updated_executions)
 
     # Update execution with persistent state
@@ -601,7 +611,7 @@ defmodule Prana.WorkflowExecution do
     existing_executions = Map.get(execution.node_executions, node_key, [])
 
     # Update node executions list
-    updated_executions = update_node_executions(existing_executions, failed_node_execution)
+    updated_executions = update_node_executions(existing_executions, failed_node_execution, loop_node?(execution, node_key))
     updated_node_executions = Map.put(execution.node_executions, node_key, updated_executions)
 
     %{
@@ -807,7 +817,7 @@ defmodule Prana.WorkflowExecution do
     existing_executions = Map.get(execution.node_executions, node_key, [])
 
     # Update node executions list
-    updated_executions = update_node_executions(existing_executions, node_execution)
+    updated_executions = update_node_executions(existing_executions, node_execution, loop_node?(execution, node_key))
     updated_node_executions = Map.put(execution.node_executions, node_key, updated_executions)
 
     %{

--- a/lib/prana/core/workflow_execution.ex
+++ b/lib/prana/core/workflow_execution.ex
@@ -496,8 +496,14 @@ defmodule Prana.WorkflowExecution do
   # This bounds memory to O(1) per node while allowing comparison with the prior iteration.
   defp update_node_executions([], new_execution, _loop_node?), do: [new_execution]
 
-  defp update_node_executions(existing_executions, new_execution, true) do
-    [new_execution, hd(existing_executions)]
+  defp update_node_executions([last | rest], new_execution, true) do
+    if last.run_index == new_execution.run_index do
+      # Same run_index = retry of current iteration: replace head, preserve previous
+      [new_execution | rest]
+    else
+      # New iteration: prepend and keep only the immediate previous entry
+      [new_execution, last]
+    end
   end
 
   defp update_node_executions(existing_executions, new_execution, false) do

--- a/test/prana/end_to_end_for_each_test.exs
+++ b/test/prana/end_to_end_for_each_test.exs
@@ -155,9 +155,11 @@ defmodule Prana.EndToEndForEachTest do
       assert {:ok, execution, _output} = run_to_completion(execution_graph, %{})
       assert execution.status == "completed"
 
-      # Verify collector ran once per item
-      collector_executions = Map.get(execution.node_executions, "collector", [])
-      assert length(collector_executions) == length(collection)
+      # Loop nodes keep only the latest NodeExecution to bound memory usage.
+      # run_index on the final entry proves all N iterations ran (0-indexed).
+      [final_collector, _prev] = Map.get(execution.node_executions, "collector", [])
+      assert final_collector.run_index == length(collection) - 1
+      assert final_collector.output_data["collected"] == List.last(collection)
     end
 
     test "completes immediately on empty collection" do
@@ -208,9 +210,10 @@ defmodule Prana.EndToEndForEachTest do
       assert {:ok, execution, _output} = run_to_completion(execution_graph, %{})
       assert execution.status == "completed"
 
-      # 5 items with batch_size 2 → 3 batches ([1,2], [3,4], [5])
-      collector_executions = Map.get(execution.node_executions, "collector", [])
-      assert length(collector_executions) == 3
+      # 5 items with batch_size 2 → 3 batches; run_index 2 proves all 3 batches ran
+      [final_collector, _prev] = Map.get(execution.node_executions, "collector", [])
+      assert final_collector.run_index == 2
+      assert final_collector.output_data["collected"] == [5]
     end
   end
 end

--- a/test/prana/execution/loopback_flag_test.exs
+++ b/test/prana/execution/loopback_flag_test.exs
@@ -262,29 +262,17 @@ defmodule Prana.Execution.LoopbackFlagTest do
 
       assert execution.status == "completed"
 
-      # Get all executions of loop_capture node
+      # Loop nodes keep [latest, previous] — 2 entries max
       loop_capture_executions = Map.get(execution.node_executions, "loop_capture", [])
+      assert length(loop_capture_executions) == 2
 
-      # Should have multiple executions (3 iterations: 0, 1, 2)
-      assert length(loop_capture_executions) == 3
-
-      # Sort by run_index to check progression
-      sorted_executions = Enum.sort_by(loop_capture_executions, & &1.run_index)
-
-      # First execution (run_index 0) - should have loopback: false
-      first_execution = Enum.at(sorted_executions, 0)
-      assert first_execution.output_data["loopback_captured"] == false
-      assert first_execution.output_data["run_index"] == 0
-
-      # Second execution (run_index 1) - should have loopback: true
-      second_execution = Enum.at(sorted_executions, 1)
-      assert second_execution.output_data["loopback_captured"] == true
-      assert second_execution.output_data["run_index"] == 1
-
-      # Third execution (run_index 2) - should have loopback: true
-      third_execution = Enum.at(sorted_executions, 2)
-      assert third_execution.output_data["loopback_captured"] == true
-      assert third_execution.output_data["run_index"] == 2
+      # Latest entry is the final iteration (run_index 2, loopback: true)
+      [final_execution, prev_execution] = loop_capture_executions
+      assert final_execution.output_data["loopback_captured"] == true
+      assert final_execution.output_data["run_index"] == 2
+      # Previous entry is the second-to-last iteration (run_index 1, loopback: true)
+      assert prev_execution.output_data["loopback_captured"] == true
+      assert prev_execution.output_data["run_index"] == 1
     end
   end
 
@@ -484,20 +472,17 @@ defmodule Prana.Execution.LoopbackFlagTest do
       assert execution.status == "completed"
 
       # Get template_test executions
+      # Loop nodes keep [latest, previous] — 2 entries max
       template_executions = Map.get(execution.node_executions, "template_test", [])
       assert length(template_executions) == 2
 
-      sorted_executions = Enum.sort_by(template_executions, & &1.run_index)
-
-      # First execution - loopback should be false
-      first = Enum.at(sorted_executions, 0)
-      assert first.output_data["is_loopback"] == false
-      assert first.output_data["run_count"] == 0
-
-      # Second execution - loopback should be true  
-      second = Enum.at(sorted_executions, 1)
-      assert second.output_data["is_loopback"] == true
-      assert second.output_data["run_count"] == 1
+      # Latest entry is the final iteration (run_index 1, loopback: true)
+      [final, prev] = template_executions
+      assert final.output_data["is_loopback"] == true
+      assert final.output_data["run_count"] == 1
+      # Previous entry is the first iteration (run_index 0, loopback: false)
+      assert prev.output_data["is_loopback"] == false
+      assert prev.output_data["run_count"] == 0
     end
   end
 end

--- a/test/prana/execution/simple_loop_test.exs
+++ b/test/prana/execution/simple_loop_test.exs
@@ -191,13 +191,10 @@ defmodule Prana.WorkflowExecution.SimpleLoopTest do
       # Verify execution completed successfully
       assert execution.status == "completed"
 
-      # Verify that multiple iterations occurred
-      # The increment node should have been executed multiple times
-      increment_executions =
-        length(Map.get(execution.node_executions, "increment", []))
-
-      # Should have 4 iterations (counter: 0 -> 1 -> 2 -> 3, then exit)
-      assert increment_executions == 4
+      # Loop nodes keep only the latest NodeExecution to bound memory usage.
+      # run_index on the final entry proves all 4 iterations ran (0-indexed → run_index 3).
+      [final_increment, _prev] = Map.get(execution.node_executions, "increment", [])
+      assert final_increment.run_index == 3
 
       # Verify the final complete node was executed
       complete_executions =


### PR DESCRIPTION
## Summary by Sourcery

Limit stored executions for loop nodes to the latest and previous iterations to bound memory usage while updating tests to assert on final run_index instead of full execution history.

Enhancements:
- Detect loop nodes via loop_level metadata and cap their node_executions list to two entries while preserving retry semantics for non-loop nodes.

Tests:
- Adjust loopback, for-each, and simple loop tests to validate behavior using the final iteration’s run_index and latest outputs under the new capped history model.