### PR TITLE
improve error return details

### DIFF
--- a/lib/prana/core/error.ex
+++ b/lib/prana/core/error.ex
@@ -121,7 +121,8 @@ defmodule Prana.Core.Error do
     :service_error,
     :api_gateway_error,
     :engine_error,
-    :workflow_error
+    :workflow_error,
+    :rate_limited
   ]
 
   @doc """

--- a/lib/prana/integrations/workflow/execute_workflow_action.ex
+++ b/lib/prana/integrations/workflow/execute_workflow_action.ex
@@ -168,20 +168,18 @@ defmodule Prana.Integrations.Workflow.ExecuteWorkflowAction do
     end
   end
 
+  defp handle_failure(%Error{} = error, "fail_parent") do
+    {:error, error}
+  end
+
   defp handle_failure(error, "fail_parent") do
-    message = extract_error_message(error)
-    {:error, Error.new("sub_workflow_failed", message, error.details)}
+    {:error, Error.new("sub_workflow_failed", "Unexpected sub-workflow error", error)}
   end
 
   defp handle_failure(error, "continue") do
     Logger.warning("Sub-workflow failed but continuing: #{inspect(error)}")
     {:ok, %{sub_workflow_failed: true, error: error}}
   end
-
-  defp extract_error_message(%Error{details: %{message: message}}) when is_binary(message), do: message
-  defp extract_error_message(%Error{message: message}) when is_binary(message), do: message
-  defp extract_error_message(error) when is_binary(error), do: error
-  defp extract_error_message(_), do: "unknown error"
 
   defp handle_timeout("fail_parent") do
     {:error, Error.new("sub_workflow_timeout", "Sub-workflow execution timed out")}

--- a/lib/prana/node_executor.ex
+++ b/lib/prana/node_executor.ex
@@ -478,7 +478,9 @@ defmodule Prana.NodeExecutor do
         {:suspend, suspended_execution}
 
       {:error, error} ->
-        # Wrap error for consistent error handling
+        # Actions may return any term as the error reason (per Action behaviour),
+        # not just an %Error{} struct - normalize before touching struct fields
+        error = normalize_error(error)
 
         details =
           if is_map(error.details) do
@@ -499,6 +501,14 @@ defmodule Prana.NodeExecutor do
           handle_resume_error(node_execution, error)
         end
     end
+  end
+
+  # Actions are allowed to return any term as the error reason - wrap non-Error
+  # terms so downstream code can safely access .code/.details/.message
+  defp normalize_error(%Error{} = error), do: error
+
+  defp normalize_error(error) do
+    Error.new("action.execution_error", "Action returned error", %{reason: error})
   end
 
   defp handle_action_execution(node, action, prepared_params, context, node_execution, execution) do

--- a/lib/prana/node_executor.ex
+++ b/lib/prana/node_executor.ex
@@ -47,7 +47,8 @@ defmodule Prana.NodeExecutor do
       handle_action_execution(node, action, validated_params, action_context, node_execution, execution)
     else
       {:error, reason} ->
-        handle_execution_error(node, node_execution, reason, execution)
+        # Preparation failures (action lookup, param templating, validation) are never retryable
+        handle_execution_error(node, node_execution, reason, execution, nil, false)
     end
   end
 
@@ -95,8 +96,8 @@ defmodule Prana.NodeExecutor do
       handle_action_result(result, node, node_execution, execution, failed_node_execution)
     else
       {:error, reason} ->
-        # For preparation failures, also handle with retry context
-        handle_execution_error(node, resumed_node_execution, reason, execution, failed_node_execution)
+        # Preparation failures are never retryable, even during a retry attempt
+        handle_execution_error(node, resumed_node_execution, reason, execution, failed_node_execution, false)
     end
   end
 
@@ -109,16 +110,18 @@ defmodule Prana.NodeExecutor do
   # - `reason` - The error that occurred
   # - `execution` - Current workflow execution (needed for error continuation)
   # - `original_failed_execution` - Original failed execution for retry scenarios (tracks attempt count)
+  # - `retryable` - Whether this error is eligible for retry. Only errors raised while actually
+  #   invoking the action (as opposed to lookup/param-prep/validation failures) are retryable.
   #
   # ## Returns
   # - `{:suspend, suspended_execution}` - Node suspended for retry
   # - `{:ok, completed_execution, updated_execution}` - Error handled with continuation
   # - `{:error, {reason, failed_execution}}` - Final failure
-  defp handle_execution_error(node, node_execution, reason, execution, original_failed_execution \\ nil) do
+  defp handle_execution_error(node, node_execution, reason, execution, original_failed_execution, retryable) do
     # Get current attempt number from original failure context (for retries) or current execution
     current_attempt = get_current_attempt_number(original_failed_execution || node_execution)
 
-    if should_retry_with_attempt?(node, current_attempt, reason) do
+    if retryable and should_retry_with_attempt?(node, current_attempt) do
       # Prepare retry suspension data with incremented attempt
       next_attempt = current_attempt + 1
 
@@ -152,11 +155,10 @@ defmodule Prana.NodeExecutor do
   end
 
   # Check if we should retry based on current attempt number
-  defp should_retry_with_attempt?(node, current_attempt, error_reason) do
+  defp should_retry_with_attempt?(node, current_attempt) do
     settings = node.settings
 
-    settings.retry_on_failed and settings.max_retries > 0 and current_attempt < settings.max_retries and
-      is_retryable_error?(error_reason)
+    settings.retry_on_failed and settings.max_retries > 0 and current_attempt < settings.max_retries
   end
 
   @doc """
@@ -431,11 +433,6 @@ defmodule Prana.NodeExecutor do
     end
   end
 
-  # Check if an error is retryable (only action execution errors should be retried)
-  defp is_retryable_error?(%Error{code: "action.execution_error"}), do: true
-
-  defp is_retryable_error?(_error), do: false
-
   # =============================================================================
   # EXECUTION HELPERS
   # =============================================================================
@@ -480,26 +477,23 @@ defmodule Prana.NodeExecutor do
         suspended_execution = NodeExecution.suspend(node_execution, suspension_type, suspension_data)
         {:suspend, suspended_execution}
 
-      {:error, reason} ->
+      {:error, error} ->
         # Wrap error for consistent error handling
-        details =
-          reason
-          |> Error.to_map()
-          |> Map.merge(%{
-            action: node && node.type,
-            node: node_execution.node_key
-          })
 
-        error =
-          Error.new(
-            "action.execution_error",
-            "Node execution failed",
-            details
-          )
+        details =
+          if is_map(error.details) do
+            error.details
+          else
+            %{reason: error.details}
+          end
+
+        details = Map.merge(details, %{action: node && node.type, node: node_execution.node_key})
+
+        error = %{error | details: details}
 
         if node do
           # execute_node or retry_node - support retry and on_error settings
-          handle_execution_error(node, node_execution, error, execution, original_failed_execution)
+          handle_execution_error(node, node_execution, error, execution, original_failed_execution, true)
         else
           # resume_node - no retry support
           handle_resume_error(node_execution, error)
@@ -539,21 +533,11 @@ defmodule Prana.NodeExecutor do
           "error"
       end
 
-    # Extract the original error information from the Error struct
-    {original_error, original_port} =
-      case reason do
-        %Error{details: %{details: _} = error} ->
-          {error, output_port}
-
-        error ->
-          {error, output_port}
-      end
-
     # Create error data with port information
     error_data =
       Error.new("action_error", "Action returned error", %{
-        error: original_error,
-        port: original_port,
+        error: reason,
+        port: output_port,
         on_error_behavior: Atom.to_string(port_type)
       })
 

--- a/test/prana/node_executor_on_error_test.exs
+++ b/test/prana/node_executor_on_error_test.exs
@@ -56,9 +56,9 @@ defmodule Prana.NodeExecutorOnErrorTest do
 
       assert {:error, {_reason, failed_execution}} = result
       assert failed_execution.status == "failed"
-      # Error is wrapped as action.execution_error with nested original error
-      assert failed_execution.error_data.code == "action.execution_error"
-      assert failed_execution.error_data.details[:code] == "action_error"
+      # Error preserves the action's own code and message
+      assert failed_execution.error_data.code == "action_error"
+      assert failed_execution.error_data.message == "This action always fails"
       assert failed_execution.output_port == nil
     end
   end
@@ -80,9 +80,9 @@ defmodule Prana.NodeExecutorOnErrorTest do
       assert completed_execution.output_port == "main"
       assert completed_execution.output_data.code == "action_error"
       assert completed_execution.output_data.message == "Action returned error"
-      # Error details are nested inside the error struct from the original action
-      assert completed_execution.output_data.details[:error][:code] == "action_error"
-      assert completed_execution.output_data.details[:error][:details][:error] == "This action always fails"
+      # The original error (preserving the action's own code/message) is nested in details
+      assert completed_execution.output_data.details[:error].code == "action_error"
+      assert completed_execution.output_data.details[:error].message == "This action always fails"
       # The port in details should be the original error port from the action
       # For "continue" mode, we route through default port but preserve original error info
       assert completed_execution.output_data.details[:on_error_behavior] == "default_port"
@@ -106,9 +106,9 @@ defmodule Prana.NodeExecutorOnErrorTest do
       assert completed_execution.output_port == "error"
       assert completed_execution.output_data.code == "action_error"
       assert completed_execution.output_data.message == "Action returned error"
-      # Error details are nested inside the error struct from the original action
-      assert completed_execution.output_data.details[:error][:code] == "action_error"
-      assert completed_execution.output_data.details[:error][:details][:error] == "This action always fails"
+      # The original error (preserving the action's own code/message) is nested in details
+      assert completed_execution.output_data.details[:error].code == "action_error"
+      assert completed_execution.output_data.details[:error].message == "This action always fails"
       assert completed_execution.output_data.details[:port] == "error"
       assert completed_execution.output_data.details[:on_error_behavior] == "error_port"
     end
@@ -153,10 +153,9 @@ defmodule Prana.NodeExecutorOnErrorTest do
       assert suspended_execution.suspension_type == :retry
       assert suspended_execution.suspension_data["attempt_number"] == 1
       assert suspended_execution.suspension_data["max_attempts"] == 3
-      # Original error should be wrapped and stored
+      # Original error preserves the action's own code and message
       original_error = suspended_execution.suspension_data["original_error"]
-      assert %Prana.Core.Error{code: "action.execution_error"} = original_error
-      assert original_error.details[:code] == "action_error"
+      assert %Prana.Core.Error{code: "action_error", message: "This action always fails"} = original_error
     end
   end
 
@@ -177,25 +176,25 @@ defmodule Prana.NodeExecutorOnErrorTest do
         case mode do
           "stop_workflow" ->
             assert {:error, {_reason, failed_execution}} = result
-            # Error is wrapped as action.execution_error with nested original error
-            assert failed_execution.error_data.code == "action.execution_error"
-            assert failed_execution.error_data.details[:code] == "action_error"
-            assert failed_execution.error_data.details[:details][:error] == "This action always fails"
+            # Error preserves the action's own code and message
+            assert failed_execution.error_data.code == "action_error"
+            assert failed_execution.error_data.message == "This action always fails"
+            assert failed_execution.error_data.details[:error] == "This action always fails"
 
           "continue" ->
             assert {:ok, completed_execution, _updated_execution} = result
             assert completed_execution.output_data.code == "action_error"
             assert completed_execution.output_data.message == "Action returned error"
-            assert completed_execution.output_data.details[:error][:code] == "action_error"
-            assert completed_execution.output_data.details[:error][:details][:error] == "This action always fails"
+            assert completed_execution.output_data.details[:error].code == "action_error"
+            assert completed_execution.output_data.details[:error].message == "This action always fails"
             assert completed_execution.output_data.details[:on_error_behavior] == "default_port"
 
           "continue_error_output" ->
             assert {:ok, completed_execution, _updated_execution} = result
             assert completed_execution.output_data.code == "action_error"
             assert completed_execution.output_data.message == "Action returned error"
-            assert completed_execution.output_data.details[:error][:code] == "action_error"
-            assert completed_execution.output_data.details[:error][:details][:error] == "This action always fails"
+            assert completed_execution.output_data.details[:error].code == "action_error"
+            assert completed_execution.output_data.details[:error].message == "This action always fails"
             assert completed_execution.output_data.details[:on_error_behavior] == "error_port"
         end
       end

--- a/test/prana/node_executor_retry_test.exs
+++ b/test/prana/node_executor_retry_test.exs
@@ -190,11 +190,10 @@ defmodule Prana.NodeExecutorRetryTest do
       resume_at = suspended_node_execution.suspension_data["resume_at"]
       assert %DateTime{} = resume_at
       assert DateTime.after?(resume_at, DateTime.utc_now())
-      # Original error is wrapped in Prana.Core.Error - NodeExecutor wraps it again
+      # Original error preserves the action's own code and message
       original_error = suspended_node_execution.suspension_data["original_error"]
-      assert %Error{code: "action.execution_error"} = original_error
-      assert original_error.details[:code] == "action_error"
-      assert original_error.details[:details][:error] == "This action always fails"
+      assert %Error{code: "action_error", message: "This action always fails"} = original_error
+      assert original_error.details[:error] == "This action always fails"
     end
 
     test "execute_node returns error when retry is disabled", %{execution: execution} do
@@ -205,10 +204,9 @@ defmodule Prana.NodeExecutorRetryTest do
       result = NodeExecutor.execute_node(node, execution, %{}, %{execution_index: 1, run_index: 0})
 
       assert {:error, {reason, failed_execution}} = result
-      # Reason is wrapped by NodeExecutor as action.execution_error containing the original Error struct
-      assert %Error{code: "action.execution_error"} = reason
-      assert reason.details[:code] == "action_error"
-      assert reason.details[:details][:error] == "This action always fails"
+      # Reason preserves the action's own code and message
+      assert %Error{code: "action_error", message: "This action always fails"} = reason
+      assert reason.details[:error] == "This action always fails"
       assert failed_execution.status == "failed"
     end
 

--- a/test/prana/node_executor_test.exs
+++ b/test/prana/node_executor_test.exs
@@ -186,6 +186,30 @@ defmodule Prana.NodeExecutorTest do
       end
     end
 
+    # Action that returns a raw (non-Error) term as the error reason
+    defmodule RawErrorAction do
+      @moduledoc false
+
+      def definition do
+        %Action{
+          name: "test.raw_error_action",
+          display_name: "Raw Error Action",
+          description: "Action that returns a raw string as the error reason",
+          type: :action,
+          input_ports: ["input"],
+          output_ports: ["main"]
+        }
+      end
+
+      def execute(_input, _context) do
+        {:error, "raw error string"}
+      end
+
+      def resume(_params, _context, _resume_data) do
+        {:error, "raw resume error string"}
+      end
+    end
+
     # Action with invalid return format
     defmodule InvalidReturn do
       @moduledoc false
@@ -307,6 +331,7 @@ defmodule Prana.NodeExecutorTest do
           TestActions.WithContext,
           TestActions.ErrorAction,
           TestActions.ErrorWithPort,
+          TestActions.RawErrorAction,
           TestActions.SuspendAction,
           TestActions.ExceptionAction,
           TestActions.InvalidReturn,
@@ -505,6 +530,18 @@ defmodule Prana.NodeExecutorTest do
 
       assert failed_execution.status == "failed"
       assert reason.code == "action.exception"
+    end
+
+    test "handles raw (non-Error) error reason without crashing", %{execution: execution} do
+      node = Node.new("test_node", "test.raw_error_action", %{})
+      routed_input = %{}
+
+      assert {:error, {reason, failed_execution}} =
+               NodeExecutor.execute_node(node, execution, routed_input, %{execution_index: 1, run_index: 0})
+
+      assert failed_execution.status == "failed"
+      assert reason.code == "action.execution_error"
+      assert reason.details[:reason] == "raw error string"
     end
 
     test "handles invalid return format", %{execution: execution} do

--- a/test/prana/node_executor_test.exs
+++ b/test/prana/node_executor_test.exs
@@ -419,7 +419,7 @@ defmodule Prana.NodeExecutorTest do
 
       assert failed_execution.status == "failed"
 
-      assert failed_execution.error_data.code == "action.execution_error"
+      assert failed_execution.error_data.code == "test_error"
 
       assert reason == failed_execution.error_data
     end
@@ -504,7 +504,7 @@ defmodule Prana.NodeExecutorTest do
                NodeExecutor.execute_node(node, execution, routed_input, %{execution_index: 1, run_index: 0})
 
       assert failed_execution.status == "failed"
-      assert reason.code == "action.execution_error"
+      assert reason.code == "action.exception"
     end
 
     test "handles invalid return format", %{execution: execution} do
@@ -515,7 +515,7 @@ defmodule Prana.NodeExecutorTest do
                NodeExecutor.execute_node(node, execution, routed_input, %{execution_index: 1, run_index: 0})
 
       assert failed_execution.status == "failed"
-      assert reason.code == "action.execution_error"
+      assert reason.code == "action.invalid_return"
     end
 
     test "handles dynamic ports", %{execution: execution} do
@@ -538,8 +538,8 @@ defmodule Prana.NodeExecutorTest do
                NodeExecutor.execute_node(node, execution, routed_input, %{execution_index: 1, run_index: 0})
 
       assert failed_execution.status == "failed"
-      assert reason.code == "action.execution_error"
-      assert reason.details[:details][:invalid_port] == "nonexistent_port"
+      assert reason.code == "action.invalid_output_port"
+      assert reason.details[:invalid_port] == "nonexistent_port"
     end
   end
 
@@ -611,7 +611,7 @@ defmodule Prana.NodeExecutorTest do
                NodeExecutor.resume_node(node, execution, suspended_execution, resume_data)
 
       assert failed_execution.status == "failed"
-      assert reason.code == "action.execution_error"
+      assert reason.code == "test_error"
     end
 
     test "handles resume action exceptions", %{execution: execution} do
@@ -633,7 +633,7 @@ defmodule Prana.NodeExecutorTest do
                NodeExecutor.resume_node(node, execution, suspended_execution, resume_data)
 
       assert failed_execution.status == "failed"
-      assert reason.code == "action.execution_error"
+      assert reason.code == "action.exception"
     end
 
     test "handles nonexistent action during resume", %{execution: execution} do


### PR DESCRIPTION
## Summary by Sourcery

Clarify retry behavior and improve error propagation so that action-specific error codes, messages, and details are preserved across node and workflow execution, while tightening when retries are allowed.

Bug Fixes:
- Ensure preparation-time failures (action lookup, parameter templating, validation) are treated as non-retryable errors in both initial execution and retry flows.
- Preserve the original action error code and message instead of wrapping all failures in a generic action.execution_error, improving accuracy of failure reporting.
- Simplify sub-workflow failure reporting by returning upstream Error structs directly when appropriate and using a consistent wrapper for unexpected non-Error failures.

Enhancements:
- Introduce an explicit retryable flag in node error handling to separate retryable action invocation failures from non-retryable preparation errors.
- Standardize error detail structures for node and on_error handling so that nested original errors and port information are exposed consistently.
- Extend the core error type taxonomy with a rate_limited type for clearer classification of throttling-related failures.

Tests:
- Update node executor, on_error, and retry tests to reflect the new error codes, messages, and detail structures, including the non-retryability of preparation errors and the preservation of original action errors.